### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To compile for windows, open in VS2019 and build.  You will need curl and sqlite
 To compile for linux:
 
 ```
-apt-get install libsqlite3-dev
+apt-get install libsqlite3-dev build-essential libcurl4-openssl-dev
 
 g++-11 -I. -std=gnu++11 -fpermissive *.cpp -lcurl -lsqlite3 -lpthread -o MiningPool
 ```


### PR DESCRIPTION
Included additional packages to satisfy dependency errors when compiling on linux.
`build-essential` -> `./compile.sh: line 3: g++: command not found`
`libcurl4-openssl-dev` -> `MiningPool/RPC.h:8:10: fatal error: curl/curl.h: No such file or directory`